### PR TITLE
Fix of CsvHelper.HeaderValidationException

### DIFF
--- a/Discord Data Package Parser/MainWindow.xaml.cs
+++ b/Discord Data Package Parser/MainWindow.xaml.cs
@@ -185,6 +185,7 @@ namespace Discord_Data_Package_Parser
                 using (var reader = new StreamReader(messageDIR + "/messages.csv"))
                 using (var csv = new CsvReader(reader))
                 {
+                    csv.Configuration.Delimiter = ",";
                     List<MessageCSV> messageCSV = csv.GetRecords<MessageCSV>().ToList();
 
                     foreach (var message in messageCSV)


### PR DESCRIPTION
This fixes this Exception when you try to open the messages file on a system locale that the default delimiter is not a comma.

Found & Solve the problem with the help of this issue
https://github.com/JoshClose/CsvHelper/issues/1201#issuecomment-487178929

**Exception & Showing the default delimiter of my system locale**
![9FwJRmR](https://user-images.githubusercontent.com/20101452/64559313-62b3b400-d31c-11e9-80a1-2b7eff707ec8.png)